### PR TITLE
Add systemd startup file to rpm 

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -13,6 +13,8 @@ For installing the software, in short, do the following (as root):
 If you want to use the provided init-script for Linux, also do
 these steps:
 
+For systems using init.d use:
+
 cp contrib/firewater.init /etc/init.d/firewater
 cp contrib/firewater.default /etc/default/firewater
 touch /etc/firewater.rules
@@ -24,6 +26,19 @@ Setup your rules using vi (or editor of choice) in /etc/firewater.rules
 Call /etc/init.d/firewater test
 and  /etc/init.d/firewater commit
 
+
+For systems using systemd use:
+
+cp contrib/firewater.service /etc/systemd/system/firewater
+cp contrib/firewater.default /etc/default/firewater
+touch /etc/firewater.rules
+
+Use systemctl to activate the firewater service script
+Edit /etc/default/firewater as you wish.
+
+Setup your rules using vi (or editor of choice) in /etc/firewater.rules
+Call source /etc/default/firewater ; /usr/bin/firewater $EXTRA_OPTIONS -v $RULESET
+and  source /etc/default/firewater ; /usr/bin/firewater $EXTRA_OPTIONS -v $RULESET > $COMPILED_RULESET
 
 
 On Debian systems you may create a package by using debian/rules

--- a/INSTALL
+++ b/INSTALL
@@ -49,6 +49,26 @@ running the following command:
 
   python ./setup.py bdist_rpm
 
+After installation of the created package do following:
+
+For systems using init.d use:
+
+rm /etc/systemd/system/firewater.service
+chkconfig firewater on
+touch /etc/firewater.rules
+service firewater test
+service firewater commit
+
+
+For systems using systemd use:
+
+rm /etc/init/d/firewater
+systemctl enable firewater.service
+touch /etc/firewater.rules
+source /etc/default/firewater ; /usr/bin/firewater $EXTRA_OPTIONS -v $RULESET
+source /etc/default/firewater ; /usr/bin/firewater $EXTRA_OPTIONS -v $RULESET > $COMPILED_RULESET
+ 
+
 For more information, please consult the documentation at:
 http://www.heiho.net/software/firewater/doc/index.html
 

--- a/contrib/firewater.service
+++ b/contrib/firewater.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Starting of firewater Server
+Description=firewater Server
 After=network.service
 
 [Service]

--- a/contrib/firewater.service
+++ b/contrib/firewater.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Starting of firewater Server
+After=network.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/default/firewater
+ExecStart=/usr/sbin/iptables-restore ${COMPILED_RULESET}
+ExecStop=/usr/sbin/iptables -F ; /usr/sbin/iptables -P INPUT ACCEPT ; /usr/sbin/iptables -P OUTPUT ACCEPT ; /usr/sbin/iptables -P FORWARD ACCEPT
+Environment=PATH=/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/firewater.service
+++ b/contrib/firewater.service
@@ -4,7 +4,10 @@ After=network.service
 
 [Service]
 Type=oneshot
-EnvironmentFile=-/etc/default/firewater
+EnvironmentFile=/etc/default/firewater
+ExecStartPre=/bin/bash -c 'if [ "$LINUX_KERNEL_SETTINGS" = "yes" ] ; then /usr/bin/echo $RP_FILTER >/proc/sys/net/ipv4/conf/all/rp_filter ; fi'
+ExecStartPre=/bin/bash -c 'if [ "$LINUX_KERNEL_SETTINGS" = "yes" ] ; then /usr/bin/echo $LOG_MARTIANS >/proc/sys/net/ipv4/conf/all/log_martians ; fi'
+ExecStartPre=/bin/bash -c 'if [ "$LINUX_KERNEL_SETTINGS" = "yes" ] ; then /usr/bin/echo $TCP_SYNCOOKIES >/proc/sys/net/ipv4/tcp_syncookies ; fi'
 ExecStart=/usr/sbin/iptables-restore ${COMPILED_RULESET}
 ExecStop=/usr/sbin/iptables -F ; /usr/sbin/iptables -P INPUT ACCEPT ; /usr/sbin/iptables -P OUTPUT ACCEPT ; /usr/sbin/iptables -P FORWARD ACCEPT
 Environment=PATH=/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ if not os.path.exists('build/etc/init.d'):
     os.makedirs('build/etc/init.d')
 shutil.copyfile('contrib/firewater.init', 'build/etc/init.d/firewater')
 
+if not os.path.exists('build/etc/systemd/system'):
+    os.makedirs('build/etc/systemd/system')
+shutil.copyfile('contrib/firewater.service', 'build/etc/systemd/system/firewater.service')
+
 if not os.path.exists('build/etc/default'):
     os.makedirs('build/etc/default')
 shutil.copyfile('contrib/firewater.default', 'build/etc/default/firewater')
@@ -59,6 +63,7 @@ setup(
         'firewater.d/logging.rules'
         ]),
         ('/etc/init.d', ['build/etc/init.d/firewater']),
+        ('/etc/systemd/system', ['build/etc/systemd/system/firewater.service']),
         ('/etc/default', ['build/etc/default/firewater'])
     ],
 )

--- a/setup_systemd.py
+++ b/setup_systemd.py
@@ -62,7 +62,7 @@ setup(
         'firewater.d/reject_all.rules',
         'firewater.d/logging.rules'
         ]),
-        ('/etc/init.d', ['build/etc/init.d/firewater']),
+        ('/etc/systemd/system', ['build/etc/systemd/system/firewater.service']),
         ('/etc/default', ['build/etc/default/firewater'])
     ],
 )


### PR DESCRIPTION
Add systemd control file.

It always installs both startup files.
For init.d and systemd. Use the instructions in INSTALL to perform actions after rpm installation.